### PR TITLE
build: manage vendor/ with melos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
         channel: 'stable'
         flutter-version: ${{env.FLUTTER_VERSION}}
     - run: flutter pub get
-    - run: flutter analyze
+    - run: flutter pub global activate melos
+    - run: melos analyze
 
   format:
     runs-on: ubuntu-22.04
@@ -37,13 +38,8 @@ jobs:
         channel: 'stable'
         flutter-version: ${{env.FLUTTER_VERSION}}
     - run: flutter pub get
-    - run: >
-          find . -name '*.dart'
-          ! -name '*.g.dart'
-          ! -name '*.freezed.dart'
-          ! -path '*/l10n/*'
-          ! -path '*/.*/*'
-          | xargs dart format --set-exit-if-changed
+    - run: flutter pub global activate melos
+    - run: melos format
 
   test:
     if: false

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ migrate_working_dir/
 .pub-cache/
 .pub/
 /build/
+pubspec_overrides.yaml
 
 # Symbolication related
 app.*.symbols

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:flutter_lints/flutter.yaml
-
-analyzer:
-  exclude:
-    - vendor/

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,41 @@
+name: ubuntu_welcome
+
+packages:
+  - .
+  - vendor/ubuntu-desktop-provision/packages**
+
+ignore:
+  - synthetic_package
+
+scripts:
+  analyze: >
+    melos exec -c 1 --scope="ubuntu_welcome" -- \
+      flutter analyze lib
+
+  format: >
+    melos exec -c 1 --fail-fast --scope="ubuntu_welcome" -- \
+      "find $MELOS_PACKAGE_PATH -name '*.dart' \
+          ! -name '*.g.dart' \
+          ! -name '*.freezed.dart' \
+          ! -path '*/l10n/*' \
+          ! -path '*/.*/*' \
+          | xargs dart format --set-exit-if-changed"
+
+  generate: >
+    melos exec -c 1 --fail-fast --depends-on="build_runner" --scope="ubuntu_welcome" -- \
+      dart run build_runner build --delete-conflicting-outputs
+
+  gen-l10n: >
+    melos exec -c 1 --fail-fast --file-exists="lib/l10n.dart" --scope="ubuntu_welcome" -- \
+     flutter gen-l10n
+
+  integration_test: >
+    melos exec -c 1 --fail-fast --dir-exists=integration_test --scope="ubuntu_welcome" -- \
+      flutter test integration_test
+
+  # runs "flutter pub <arg(s)>" in all packages
+  pub: melos exec -c 1 -- flutter pub "$@"
+
+  test: >
+    melos exec -c 1 --fail-fast --dir-exists=test --scope="ubuntu_welcome" -- \
+      flutter test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: ^2.0.0
+  melos: ^3.0.0
 
 flutter:
   generate: true


### PR DESCRIPTION
It wasn't a good idea to ignore `vendor/` from the Dart analyzer. Even if it no longer turns red by default, it's also not possible to do anything sensible with the files unless they are analyzed. The only way to avoid all-red `vendor/` yet to be able to work with the files is to run pub get for them - Melos is handy for that. All other Melos actions are scoped to `ubuntu_welcome` except pub get (and the default bootstrap).