### PR TITLE
fix: use GlobalUbuntuInitLocalizations.delegates

### DIFF
--- a/lib/l10n.dart
+++ b/lib/l10n.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:ubuntu_localizations/ubuntu_localizations.dart';
-import 'package:ubuntu_provision/l10n.dart';
+import 'package:ubuntu_init/ubuntu_init.dart';
 
 export 'package:flutter_gen/gen_l10n/app_localizations.dart';
 export 'package:ubuntu_localizations/ubuntu_localizations.dart';
@@ -9,6 +8,5 @@ export 'package:ubuntu_provision/l10n.dart';
 
 const localizationsDelegates = <LocalizationsDelegate<dynamic>>[
   ...AppLocalizations.localizationsDelegates,
-  ...UbuntuProvisionLocalizations.localizationsDelegates,
-  ...GlobalUbuntuLocalizations.delegates,
+  ...GlobalUbuntuInitLocalizations.delegates,
 ];


### PR DESCRIPTION
Provides the missing `UbuntuInitLocalizations` delegate that was introduced together with the newly added pages.

```
flutter: ERROR ubuntu_welcome: Unhandled exception
	_TypeError: Null check operator used on a null value
#0      WelcomeLocalizations.of      welcome_l10n.dart:9
#1      WelcomePage.build            welcome_page.dart:21
```