### PR TITLE
build: add snap archs, plugs, stage utils

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,9 @@ confinement: strict
 base: core22
 issues: https://github.com/canonical/ubuntu-welcome/issues
 contact: https://github.com/canonical/ubuntu-welcome/issues
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 
 apps:
   ubuntu-welcome:
@@ -18,6 +21,9 @@ apps:
       LOG_LEVEL: debug
     plugs:
       - desktop-launch
+      - hardware-observe
+      - system-observe
+      - telemetry
 
 parts:
   flutter-git:
@@ -55,6 +61,20 @@ parts:
       cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
     stage-packages:
       - libsysmetrics1
+      - pciutils
+      - util-linux
+
+lint:
+  ignore:
+    - library:
+        - usr/lib/**/libsysmetrics.so.1
+
+plugs:
+  telemetry:
+    interface: system-files
+    read:
+      - /var/log/installer/telemetry
+      - /var/log/upgrade/telemetry
 
 slots:
   dbus-name:


### PR DESCRIPTION
## Before:
```
Lint warnings:                                                                                                                                                           
- library: libsysmetrics.so.1: unused library 'usr/lib/x86_64-linux-gnu/libsysmetrics.so.1'. (https://snapcraft.io/docs/linters-library)
```
```
INFO[0000] Couldn't get glibc version: error while scanning: '[dpkg --status libc6]' return an error: exec: "dpkg": executable file not found in $PATH 
INFO[0000] couldn't get sys vendor information: couldn't open /sys/class/dmi/id/sys_vendor: open /sys/class/dmi/id/sys_vendor: permission denied 
INFO[0000] couldn't get sys product name information: couldn't open /sys/class/dmi/id/product_name: open /sys/class/dmi/id/product_name: permission denied 
INFO[0000] couldn't get sys product family information: couldn't open /sys/class/dmi/id/product_family: open /sys/class/dmi/id/product_family: permission denied 
INFO[0000] no DCD information: couldn't open /var/lib/ubuntu_dist_channel: open /var/lib/ubuntu_dist_channel: no such file or directory 
INFO[0000] couldn't get bios vendor information: couldn't open /sys/class/dmi/id/bios_vendor: open /sys/class/dmi/id/bios_vendor: permission denied 
INFO[0000] couldn't get bios version: couldn't open /sys/class/dmi/id/bios_version: open /sys/class/dmi/id/bios_version: permission denied 
INFO[0000] Couldn't get CPU info: error while scanning: '[lscpu -J]' return an error: fork/exec /usr/bin/lscpu: permission denied 
INFO[0000] couldn't get Architecture: exec: "dpkg": executable file not found in $PATH 
INFO[0000] couldn't get GPU info: error while scanning: '[lspci -n]' return an error: exec: "lspci": executable file not found in $PATH 
INFO[0000] couldn't get disk block information: open /sys/block: permission denied 
INFO[0000] couldn't get Disk info: error while scanning: '[df]' return an error: fork/exec /usr/bin/df: permission denied 
INFO[0000] couldn't get Screen info: error while scanning: '[xrandr]' return an error: exec: "xrandr": executable file not found in $PATH 
INFO[0000] couldn't get autologin information from gdm: couldn't open /etc/gdm3/custom.conf: open /etc/gdm3/custom.conf: permission denied 
INFO[0000] no install data found: couldn't open /var/log/installer/telemetry: open /var/log/installer/telemetry: permission denied 
INFO[0000] no upgrade data found: couldn't open /var/log/upgrade/telemetry: open /var/log/upgrade/telemetry: permission denied 
```
![image](https://github.com/canonical/ubuntu-welcome/assets/140617/719b664f-7102-4c5c-9bf9-2f629ecd7507)

## After:
```
INFO[0000] Couldn't get glibc version: error while scanning: '[dpkg --status libc6]' return an error: exec: "dpkg": executable file not found in $PATH 
INFO[0000] no DCD information: couldn't open /var/lib/ubuntu_dist_channel: open /var/lib/ubuntu_dist_channel: no such file or directory 
INFO[0000] couldn't get Architecture: exec: "dpkg": executable file not found in $PATH 
INFO[0001] couldn't get Disk info: error while scanning: '[df]' return an error: fork/exec /usr/bin/df: permission denied 
INFO[0001] couldn't get Screen info: error while scanning: '[xrandr]' return an error: exec: "xrandr": executable file not found in $PATH 
INFO[0001] couldn't get autologin information from gdm: couldn't open /etc/gdm3/custom.conf: open /etc/gdm3/custom.conf: permission denied
```
![image](https://github.com/canonical/ubuntu-welcome/assets/140617/9e6e35fb-cb0f-4cdf-8ac2-6e5163904cae)

Ref: #31 