### PR TITLE
Rename system-files plugs to match accepted convention

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,8 @@ apps:
       - desktop-launch
       - hardware-observe
       - system-observe
-      - telemetry
+      - var-log-installer-telemetry
+      - var-log-upgrade-telemetry
 
 parts:
   flutter-git:
@@ -70,10 +71,13 @@ lint:
         - usr/lib/**/libsysmetrics.so.1
 
 plugs:
-  telemetry:
+  var-log-installer-telemetry:
     interface: system-files
     read:
       - /var/log/installer/telemetry
+  var-log-upgrade-telemetry:
+    interface: system-files
+    read:
       - /var/log/upgrade/telemetry
 
 slots:


### PR DESCRIPTION
system-files plugs are expected to follow a naming convention that makes it obvious what paths are being exposed.