### PR TITLE
snap: use log-observe instead of system-files

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,9 +22,8 @@ apps:
     plugs:
       - desktop-launch
       - hardware-observe
+      - log-observe
       - system-observe
-      - var-log-installer-telemetry
-      - var-log-upgrade-telemetry
 
 parts:
   flutter-git:
@@ -69,16 +68,6 @@ lint:
   ignore:
     - library:
         - usr/lib/**/libsysmetrics.so.1
-
-plugs:
-  var-log-installer-telemetry:
-    interface: system-files
-    read:
-      - /var/log/installer/telemetry
-  var-log-upgrade-telemetry:
-    interface: system-files
-    read:
-      - /var/log/upgrade/telemetry
 
 slots:
   dbus-name:


### PR DESCRIPTION
Proposed at: https://forum.snapcraft.io/t/auto-connect-request-for-ubuntu-welcome/36312/3