### PR TITLE
snap: drop desktop-launch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,7 +20,6 @@ apps:
     environment:
       LOG_LEVEL: debug
     plugs:
-      - desktop-launch
       - hardware-observe
       - log-observe
       - system-observe


### PR DESCRIPTION
No more needed after:
- https://github.com/canonical/ubuntu-desktop-provision/pull/84

Originally proposed at: https://forum.snapcraft.io/t/auto-connect-request-for-ubuntu-welcome/36312/3